### PR TITLE
Make chill safer and allow sudo to run aliased commands

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -23,13 +23,16 @@ killport() {
   lsof -nti:$1 | xargs kill -9
 }
 
+# Allow sudo to expand aliases by making sudo itself an alias
+alias sudo='sudo '
+
 # When pre-installed trash decides to eat up every CPU core
 chill() {
   TARGET=$1
   while true; do
     PROCESS_TO_CHILL=$(ps -ax | grep -m 1 $TARGET | awk '{print $1}')
     echo "Telling $TARGET($PROCESS_TO_CHILL) to chill for a sec"
-    sudo kill $PROCESS_TO_CHILL
+    kill $PROCESS_TO_CHILL
     sleep 3
   done
 }


### PR DESCRIPTION
Fix #1 

You will be able to run `chill` vs `sudo chill` and the former will not accidentally kill root processes if the target is malformed.  Note that the former may error out if the unprivileged `kill` tries to kill a root process.